### PR TITLE
fix workflow files missing Windows ARM64 libs

### DIFF
--- a/.github/workflows/build-release.yaml
+++ b/.github/workflows/build-release.yaml
@@ -14,6 +14,7 @@ on:
       - 'mac/*'
       - 'win32/*'
       - 'win64/*'
+      - 'winarm64/*'
     
   workflow_dispatch:
     # Triggered manually from Github
@@ -47,3 +48,4 @@ jobs:
             mac/bin-mac.tar.gz
             win32/bin-win32.zip
             win64/bin-win64.zip
+            winarm64/bin-winarm64.zip

--- a/ci/script.sh
+++ b/ci/script.sh
@@ -29,3 +29,4 @@ git push deploy --tags
 
 (cd win32 && 7z a -r bin-win32.zip *)
 (cd win64 && 7z a -r bin-win64.zip *)
+(cd winarm64 && 7z a -r bin-winarm64.zip *)


### PR DESCRIPTION
Another thing that appeared to get missed in the cherry-pick. This adds the Windows ARM64 files to the workflow and packaging script so that they are included with the release.